### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bootstrap Snippets for Visual Studio
 =====================================
 
-##The ultimate snippet pack for web developers using the Twitter Bootstrap framework
+## The ultimate snippet pack for web developers using the Twitter Bootstrap framework
 
 Contains a collection of [Twitter Bootstrap](https://getbootstrap.com/) snippets for Visual Studio 2012/2013/2015/2017.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
