### PR TITLE
Set InstallationTarget for supporting VSCommunity

### DIFF
--- a/BootstrapSnippets/source.extension.vsixmanifest
+++ b/BootstrapSnippets/source.extension.vsixmanifest
@@ -15,7 +15,7 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0]" />
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0]" />
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0]" />
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
The current source.extension.vsixmanifest can't support Visual Studio 2017 Community edition.